### PR TITLE
Improve deduplication of issues for Cx

### DIFF
--- a/sast_controller/converters/CheckmarxReport.py
+++ b/sast_controller/converters/CheckmarxReport.py
@@ -86,6 +86,7 @@ class CheckmarxReport(BaseReport):
         branch = os.environ.get('BRANCH', '')
         if not repo:
             self._get_repo(repo, cx_client)
+        existing_results = set()
         for query in self.report:
             group = query.attrib.get("group")
             query_id = query.attrib.get("id")
@@ -95,18 +96,12 @@ class CheckmarxReport(BaseReport):
             if category and category.rfind(";"):
                 category_place = category.rfind(";") + 1
                 category = category[category_place:]
-            existing_results = set()
             for result in query:
                 for path_ in result:
                     result_file = result.attrib["FileName"]
                     name = query.attrib.get("name")
                     language = query.attrib.get("Language")
                     line = result.attrib.get("Line")
-                    # do not append multiple results with the same file an line of code to report
-                    if result_file + line not in existing_results:
-                        existing_results.add(result_file + line)
-                    else:
-                        continue
                     result_state = result.attrib.get('state')
                     remark = result.attrib.get("Remark")
                     rp_defect_type = RP_DEFECT_TYPES[result_state]
@@ -181,6 +176,11 @@ class CheckmarxReport(BaseReport):
                     else:
                         issue["Description"] = self.info_message.format(desc, group, category,
                                                                         snippet[:100])
+                    # do not append multiple results with the same file and line of code to report
+                    if result_file + line + name not in existing_results:
+                        existing_results.add(result_file + line + name)
+                    else:
+                        continue
                     report.append(issue)
         print("Checkmarx report generation finished")
         self.new_items[self.tool_name] = bugbar_vulns.difference(existing_bb)

--- a/sast_controller/tests/convertors/checkmarx_report.xml
+++ b/sast_controller/tests/convertors/checkmarx_report.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <CxXMLResults InitiatorName="test scanner" Owner="SAML\\User.B@email.com" ScanId="1027717" ProjectId="3076" ProjectName="my_project" TeamFullPathOnReportDate="CxServer\\SP\\My Company\\test" DeepLink="https://sast.mysite.com/CxWebClient/ViewerMain.aspx?scanid=1027717&amp;projectid=3076" ScanStart="Friday, February 15, 2019 5:36:17 PM" Preset="Checkmarx Default" ScanTime="00h:03m:17s" LinesOfCodeScanned="130631" FilesScanned="148" ReportCreationTime="Tuesday, February 19, 2019 11:40:47 AM" Team="test" CheckmarxVersion="8.8.0.72 HF8" ScanComments="Running from code" ScanType="Incremental" SourceOrigin="LocalPath" Visibility="Public">
   <Query id="427" categories="PCI DSS v3.2;PCI DSS (3.2) - 6.5.7 - Cross-site scripting (XSS),OWASP Top 10 2013;A3-Cross-Site Scripting (XSS),FISMA 2014;System And Information Integrity,NIST SP 800-53;SI-15 Information Output Filtering (P0),OWASP Top 10 2017;A7-Cross-Site Scripting (XSS)" cweId="79" name="Reflected_XSS_All_Clients" group="CSharp_High_Risk" Severity="High" Language="CSharp" LanguageHash="0978409962023014" LanguageChangeDate="2018-08-30T00:00:00.0000000" SeverityIndex="3" QueryPath="CSharp\\Cx\\CSharp High Risk\\Reflected XSS All Clients Version:1" QueryVersionCode="54386807">
-    <Result NodeId="10277170011" FileName="code/src/MyApp.Api.Web/Controllers/ArticlesController.cs" Status="Recurrent" Line="553" Column="101" FalsePositive="False" Severity="High" AssignToUser="" state="0" Remark="" DeepLink="https://sast.mysite.com/CxWebClient/ViewerMain.aspx?scanid=1027717&amp;projectid=3076&amp;pathid=11" SeverityIndex="3">
+    <Result NodeId="10277170011" FileName="code/src/MyApp.Api.Web/Controllers/Controller.cs" Status="Recurrent" Line="553" Column="101" FalsePositive="False" Severity="High" AssignToUser="" state="0" Remark="" DeepLink="https://sast.mysite.com/CxWebClient/ViewerMain.aspx?scanid=1027717&amp;projectid=3076&amp;pathid=11" SeverityIndex="3">
       <Path ResultId="1027717" PathId="11" SimilarityId="646560328">
         <PathNode>
-          <FileName>code/src/MyApp.Api.Web/Controllers/ArticlesController.cs</FileName>
+          <FileName>code/src/MyApp.Api.Web/Controllers/Controller.cs</FileName>
           <Line>553</Line>
           <Column>101</Column>
           <NodeId>1</NodeId>
@@ -14,12 +14,12 @@
           <Snippet>
             <Line>
               <Number>553</Number>
-              <Code>        public IActionResult PostTranslateDjml([FromBody] JsonApiResponse&lt;ArticleData, MetaArticle&gt; article, [FromServices] IContentTranslation contentTranslation)</Code>
+              <Code>        public IActionResult PostTranslate(JsonApiResponse article, IContentTranslation contentTranslation)</Code>
             </Line>
           </Snippet>
         </PathNode>
         <PathNode>
-          <FileName>code/src/MyApp.Api.Web/Controllers/ArticlesController.cs</FileName>
+          <FileName>code/src/MyApp.Api.Web/Controllers/Controller.cs</FileName>
           <Line>555</Line>
           <Column>56</Column>
           <NodeId>2</NodeId>
@@ -29,16 +29,16 @@
           <Snippet>
             <Line>
               <Number>555</Number>
-              <Code>            var xml = contentTranslation.ArticleToDjml(article);</Code>
+              <Code>            var xml = contentTranslation.Convert(article);</Code>
             </Line>
           </Snippet>
         </PathNode>
       </Path>
     </Result>
-    <Result NodeId="10277170012" FileName="code/src/MyApp.Api.Web/Controllers/ArticlesController.cs" Status="Recurrent" Line="467" Column="67" FalsePositive="False" Severity="High" AssignToUser="" state="2" Remark="Oleksii C my_project, [Monday, July 29, 2019 10:36:13 AM]: Changed status to Confirmed&#xD;&#xA;Oleksii C my_project, [Monday, July 29, 2019 10:35:47 AM]: Changed status to Not Exploitable" DeepLink="https://sast.mysite.com/CxWebClient/ViewerMain.aspx?scanid=1027717&amp;projectid=3076&amp;pathid=12" SeverityIndex="3">
+    <Result NodeId="10277170012" FileName="code/src/MyApp.Api.Web/Controllers/Controller.cs" Status="Recurrent" Line="467" Column="67" FalsePositive="False" Severity="High" AssignToUser="" state="2" Remark="Oleksii C my_project, [Monday, July 29, 2019 10:36:13 AM]: Changed status to Confirmed&#xD;&#xA;Oleksii C my_project, [Monday, July 29, 2019 10:35:47 AM]: Changed status to Not Exploitable" DeepLink="https://sast.mysite.com/CxWebClient/ViewerMain.aspx?scanid=1027717&amp;projectid=3076&amp;pathid=12" SeverityIndex="3">
       <Path ResultId="1027717" PathId="12" SimilarityId="1722761064">
         <PathNode>
-          <FileName>code/src/MyApp.Api.Web/Controllers/ArticlesController.cs</FileName>
+          <FileName>code/src/MyApp.Api.Web/Controllers/Controller.cs</FileName>
           <Line>467</Line>
           <Column>67</Column>
           <NodeId>1</NodeId>
@@ -48,12 +48,12 @@
           <Snippet>
             <Line>
               <Number>467</Number>
-              <Code>        public async Task&lt;IActionResult&gt; GetDjmlByOriginId(string id, [FromHeader(Name= "x-api-key")] string apiKey)</Code>
+              <Code>        public async Task&lt;IActionResult&gt; GetById(string id, string apiKey)</Code>
             </Line>
           </Snippet>
         </PathNode>
         <PathNode>
-          <FileName>code/src/MyApp.Api.Web/Controllers/ArticlesController.cs</FileName>
+          <FileName>code/src/MyApp.Api.Web/Controllers/Controller.cs</FileName>
           <Line>474</Line>
           <Column>82</Column>
           <NodeId>2</NodeId>
@@ -63,7 +63,43 @@
           <Snippet>
             <Line>
               <Number>474</Number>
-              <Code>                    var article = await _articleGateway.GetDjmlByExternalIdAsync(id);</Code>
+              <Code>                    var article = await repository.Get(id);</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+      </Path>
+    </Result>
+  </Query>
+  <Query id="427" categories="PCI DSS v3.2;PCI DSS (3.2) - 6.5.7 - Cross-site scripting (XSS),OWASP Top 10 2013;A3-Cross-Site Scripting (XSS),FISMA 2014;System And Information Integrity,NIST SP 800-53;SI-15 Information Output Filtering (P0),OWASP Top 10 2017;A7-Cross-Site Scripting (XSS)" cweId="79" name="Reflected_XSS_All_Clients" group="CSharp_High_Risk" Severity="High" Language="CSharp" LanguageHash="0978409962023014" LanguageChangeDate="2018-08-30T00:00:00.0000000" SeverityIndex="3" QueryPath="CSharp\\Cx\\CSharp High Risk\\Reflected XSS All Clients Version:1" QueryVersionCode="54386807">
+    <Result NodeId="10277170012" FileName="code/src/MyApp.Api.Web/Controllers/Controller.cs" Status="Recurrent" Line="467" Column="67" FalsePositive="False" Severity="High" AssignToUser="" state="2" Remark="Oleksii C my_project, [Monday, July 29, 2019 10:36:13 AM]: Changed status to Confirmed&#xD;&#xA;Oleksii C my_project, [Monday, July 29, 2019 10:35:47 AM]: Changed status to Not Exploitable" DeepLink="https://sast.mysite.com/CxWebClient/ViewerMain.aspx?scanid=1027717&amp;projectid=3076&amp;pathid=12" SeverityIndex="3">
+      <Path ResultId="1027717" PathId="12" SimilarityId="1722761064">
+        <PathNode>
+          <FileName>code/src/MyApp.Api.Web/Controllers/Controller.cs</FileName>
+          <Line>467</Line>
+          <Column>67</Column>
+          <NodeId>1</NodeId>
+          <Name>id</Name>
+          <Type></Type>
+          <Length>2</Length>
+          <Snippet>
+            <Line>
+              <Number>467</Number>
+              <Code>        public async Task&lt;IActionResult&gt; GetById(string id, string apiKey)</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>code/src/MyApp.Api.Web/Controllers/Controller.cs</FileName>
+          <Line>474</Line>
+          <Column>82</Column>
+          <NodeId>2</NodeId>
+          <Name>id</Name>
+          <Type></Type>
+          <Length>2</Length>
+          <Snippet>
+            <Line>
+              <Number>474</Number>
+              <Code>                    var article = await repository.Get(id);</Code>
             </Line>
           </Snippet>
         </PathNode>

--- a/sast_controller/tests/convertors/test_checkmarx_report.py
+++ b/sast_controller/tests/convertors/test_checkmarx_report.py
@@ -37,11 +37,11 @@ EXPECTED_REPORT = [{
                    '    GROUP: CSharp_High_Risk\n'
                    '    CATEGORY: A7-Cross-Site Scripting (XSS)\n'
                    '    *Code*:\n'
-                   '    ``` public IActionResult PostTranslateDjml([FromBody] '
-                   'JsonApiResponse<ArticleData, MetaArticle> article, ```',
-    'Instances': 'File code/src/MyApp.Api.Web/Controllers/ArticlesController.cs',
+                   '    ``` public IActionResult PostTranslate(JsonApiResponse '
+                   'article, IContentTranslation contentTranslation) ```',
+    'Instances': 'File code/src/MyApp.Api.Web/Controllers/Controller.cs',
     'Issue Confidence': 'Certain',
-    'Issue Name': 'Cross-site Scripting (XSS).code/src/MyApp.Api.Web/Controllers/ArticlesController.cs',
+    'Issue Name': 'Cross-site Scripting (XSS).code/src/MyApp.Api.Web/Controllers/Controller.cs',
     'Issue Priority': 'Major',
     'Issue Severity': 'High',
     'Issue Tool': 'Checkmarx',
@@ -51,21 +51,20 @@ EXPECTED_REPORT = [{
     'Paths': '',
     'RP Comment': '',
     'RP Defect Type': 'To Investigate',
-    'Recommendations': 'Please review and modify vulnerable code in line 553 of ArticlesController.cs',
+    'Recommendations': 'Please review and modify vulnerable code in line 553 of Controller.cs',
     'References': 'Line 553 in file '
-                  '[code/src/MyApp.Api.Web/Controllers/ArticlesController.cs|https://sast.mysite.com/CxWebClient/'
+                  '[code/src/MyApp.Api.Web/Controllers/Controller.cs|https://sast.mysite.com/CxWebClient/'
                   'ViewerMain.aspx?scanid=1027717&projectid=3076&pathid=11]',
     'Repo': 'https://github.com/myrepo',
-    'Snippet': 'public IActionResult PostTranslateDjml([FromBody] '
-               'JsonApiResponse<ArticleData, MetaArticle> article, '
-               '[FromServices] IContentTranslation contentTranslation)',
+    'Snippet': 'public IActionResult PostTranslate(JsonApiResponse article, '
+               'IContentTranslation contentTranslation)',
     'Steps To Reproduce': '',
     'Tags': [
         {'TestType': 'sast'},
         {'Provider': 'Reapsaw'},
         {'Tool': 'Checkmarx'}],
     'error_string': 'Cross-site Scripting (XSS) 79\n'
-                    'code/src/MyApp.Api.Web/Controllers/ArticlesController.cs'}, {
+                    'code/src/MyApp.Api.Web/Controllers/Controller.cs'}, {
     'Attachments': [],
     'CVE': '',
     'CWE': '[CWE-79|https://cwe.mitre.org/data/definitions/79]',
@@ -73,12 +72,11 @@ EXPECTED_REPORT = [{
                    '    GROUP: CSharp_High_Risk\n'
                    '    CATEGORY: A7-Cross-Site Scripting (XSS)\n'
                    '    *Code*:\n'
-                   '    ``` public async Task<IActionResult> '
-                   'GetDjmlByOriginId(string id, [FromHeader(Name= '
-                   '"x-api-key")] string ```',
-    'Instances': 'File code/src/MyApp.Api.Web/Controllers/ArticlesController.cs',
+                   '    ``` public async Task<IActionResult> GetById(string id, '
+                   'string apiKey) ```',
+    'Instances': 'File code/src/MyApp.Api.Web/Controllers/Controller.cs',
     'Issue Confidence': 'Certain',
-    'Issue Name': 'Cross-site Scripting (XSS).code/src/MyApp.Api.Web/Controllers/ArticlesController.cs',
+    'Issue Name': 'Cross-site Scripting (XSS).code/src/MyApp.Api.Web/Controllers/Controller.cs',
     'Issue Priority': 'Major',
     'Issue Severity': 'High',
     'Issue Tool': 'Checkmarx',
@@ -91,20 +89,20 @@ EXPECTED_REPORT = [{
                   'Oleksii C my_project, [Monday, July 29, 2019 10:35:47 AM]: '
                   'Changed status to Not Exploitable',
     'RP Defect Type': 'Product Bug',
-    'Recommendations': 'Please review and modify vulnerable code in line 553 of ArticlesController.cs',
+    'Recommendations': 'Please review and modify vulnerable code in line 553 of Controller.cs',
     'References': 'Line 467 in file '
-                  '[code/src/MyApp.Api.Web/Controllers/ArticlesController.cs|https://sast.mysite.com/CxWebClient/'
+                  '[code/src/MyApp.Api.Web/Controllers/Controller.cs|https://sast.mysite.com/CxWebClient/'
                   'ViewerMain.aspx?scanid=1027717&projectid=3076&pathid=12]',
     'Repo': 'https://github.com/myrepo',
-    'Snippet': 'public async Task<IActionResult> GetDjmlByOriginId(string '
-               'id, [FromHeader(Name= "x-api-key")] string apiKey)',
+    'Snippet': 'public async Task<IActionResult> GetById(string id, string '
+               'apiKey)',
     'Steps To Reproduce': '',
     'Tags': [
         {'TestType': 'sast'},
         {'Provider': 'Reapsaw'},
         {'Tool': 'Checkmarx'}],
     'error_string': 'Cross-site Scripting (XSS) 79\n'
-                    'code/src/MyApp.Api.Web/Controllers/ArticlesController.cs'}
+                    'code/src/MyApp.Api.Web/Controllers/Controller.cs'}
 ]
 
 
@@ -154,7 +152,7 @@ class TestCheckmarxReport(unittest.TestCase):
         for _ in expected:
             _['Instances'] = \
                 'File ' \
-                'https://github.com/myrepo/blob/develop/code/src/MyApp.Api.Web/Controllers/ArticlesController.cs'
+                'https://github.com/myrepo/blob/develop/code/src/MyApp.Api.Web/Controllers/Controller.cs'
         self.assertEqual(expected, cx_report.report)
         self.assertEqual({'Checkmarx': set()}, cx_report.new_items)
 


### PR DESCRIPTION
It's possible that the issue with the same name will go to different query results
in Cx report. As a result, we display several identical issues in one jira
ticket (group and category will be different though).
Deduplication key is updated to contain the name of the issue.
Test data is updated correspondingly.